### PR TITLE
Add *Teleport and *ArbiterContract messages

### DIFF
--- a/cReplyThroughArbiterContract.def
+++ b/cReplyThroughArbiterContract.def
@@ -1,0 +1,6 @@
+offset  recipient
+
+uint32  type
+uint64  id
+uint32  response
+string  recipient

--- a/protocol/cReplyTeleport.def
+++ b/protocol/cReplyTeleport.def
@@ -1,0 +1,1 @@
+byte accept  # 1 = yes, 0 = no

--- a/protocol/sAskTeleport.def
+++ b/protocol/sAskTeleport.def
@@ -1,0 +1,3 @@
+offset name
+uint32 timeout
+string name

--- a/sBeginThroughArbiterContract.def
+++ b/sBeginThroughArbiterContract.def
@@ -1,0 +1,9 @@
+offset  sender
+offset  recipient
+
+uint16  unk1
+uint32  type
+uint64  id
+string  sender
+string  recipient
+uint16  unk2


### PR DESCRIPTION
Sorry, I meant to split this into two PRs but it got mixed up.

`cReplyTeleport` is for accepting summons -- pretty straightforward. `cReplyThroughArbiterContract` seems to have multiple uses. One example would be accepting party invitations (`type = 4`, `response = 1`). Gonna investigate this one further.

Also, what's your IGN? I'd love to have a chat.