### PR TITLE
Add fear move defs

### DIFF
--- a/protocol/sFearmoveEnd.def
+++ b/protocol/sFearmoveEnd.def
@@ -1,0 +1,8 @@
+uint64  target
+uint32  time
+float   x
+float   y
+float   z
+int16   w
+uint16  speed
+uint32  unk   # 25?

--- a/protocol/sFearmoveStage.def
+++ b/protocol/sFearmoveStage.def
@@ -1,0 +1,11 @@
+uint64  target
+uint32  time
+float   x1
+float   y1
+float   z1
+int16   w
+uint16  speed
+float   x2
+float   y2
+float   z2
+uint32  unk


### PR DESCRIPTION
Okay, I got a little curious since you mentioned these are a thing.

The `time` field is super tentative, since I'm not actually sure if that's what it's supposed to represent. I did some testing with mystic's fear and each cast (unglyphed) fires off four `sFearmoveStage` packets followed by one `sFearmoveEnd` packet. Each of these packets has the same value for `time`. Successive casts seem to increase this, but apparently not by the number of milliseconds that have passed since. It could be some random number that the server chooses to keep the packets in the correct order. I'm just speculating wildly here. Tried setting it to zero and it made no difference in the client.

Anyway, gonna see if this can be used to emulate client-side player movement.