### PR TITLE
Create sOpenAwesomiumWebUrl.def

### DIFF
--- a/protocol/sOpenAwesomiumWebUrl.def
+++ b/protocol/sOpenAwesomiumWebUrl.def
@@ -1,0 +1,2 @@
+offset url
+string url


### PR DESCRIPTION
This is kinda funny. You can play Flash videos with it too. Also, `url` is without the protocol part, so `example.com` instead of `http://example.com`. The protocol is always http.