### PR TITLE
Create cSetVisibleRange.def

### DIFF
--- a/protocol/cSetVisibleRange.def
+++ b/protocol/cSetVisibleRange.def
@@ -1,0 +1,1 @@
+uint32 range


### PR DESCRIPTION
This is the PC view distance setting.

```
Preset  Range
-------------
0       1000
1       1200
2       1400
3       1600
4       1800
5       2000
6       2500
```

Seems to be capped at 2500. Setting it to 0 is possible too, which basically results in an empty world.