### PR TITLE
unk5 changed to bonusRe

### DIFF
--- a/protocol/sPlayerStatUpdate.def
+++ b/protocol/sPlayerStatUpdate.def
@@ -52,7 +52,7 @@ int32 bonusRe
 int32 unk6
 int32 itemLevelInventory
 int32 itemLevel
-int32 unk7
+int32 edge
 int32 unk8
 int32 unk9  # 0x1F40 = 8000
 int32 unk10 # 3

--- a/protocol/sPlayerStatUpdate.def
+++ b/protocol/sPlayerStatUpdate.def
@@ -48,7 +48,7 @@ int32 curStamina
 int32 maxStamina
 int32 curRe
 int32 maxRe
-int32 unk5
+int32 bonusRe
 int32 unk6
 int32 itemLevelInventory
 int32 itemLevel


### PR DESCRIPTION
bonusRe is added to maxRe to obtain total player's Re (for example lancer's max RE glyph: maxRe = 1500, bonusRe = 500)